### PR TITLE
Handle both OpenAI API versions

### DIFF
--- a/backend/App.py
+++ b/backend/App.py
@@ -3,13 +3,35 @@ import base64
 import tempfile
 import os
 from flask_cors import CORS
-from openai import OpenAI
+import openai
 from dotenv import load_dotenv
 
 load_dotenv()
 
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
-client = OpenAI(api_key=OPENAI_API_KEY)
+
+try:
+    # Preferred interface for openai>=1.0
+    from openai import OpenAI
+    client = OpenAI(api_key=OPENAI_API_KEY)
+
+    def whisper_transcribe(audio_file):
+        result = client.audio.transcriptions.create(
+            file=audio_file,
+            model="whisper-1",
+            language="he",
+        )
+        return result.text
+except Exception:  # Fallback for openai<1.0
+    openai.api_key = OPENAI_API_KEY
+
+    def whisper_transcribe(audio_file):
+        result = openai.Audio.transcribe(
+            model="whisper-1",
+            file=audio_file,
+            language="he",
+        )
+        return result["text"]
 
 app = Flask(__name__)
 CORS(app)
@@ -26,17 +48,13 @@ def transcribe():
             tmp_file.write(file_data)
             tmp_file_path = tmp_file.name
 
-        # Use new SDK structure with 'client.audio.transcriptions.create(...)'
+        # Transcribe using whichever OpenAI interface is available
         with open(tmp_file_path, "rb") as audio_file:
-            transcription = client.audio.transcriptions.create(
-                file=audio_file,
-                model="whisper-1",
-                language="he"
-            )
+            transcription_text = whisper_transcribe(audio_file)
 
         os.remove(tmp_file_path)
 
-        return jsonify({"transcription": transcription.text})
+        return jsonify({"transcription": transcription_text})
 
     except Exception as e:
         print("Error:", str(e))


### PR DESCRIPTION
## Summary
- add fallback support for legacy `openai.Audio` API
- make transcription route call version-agnostic helper

## Testing
- `python -m py_compile backend/App.py`
- `npm run lint` *(fails: `expo: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684f2feee0f48324abac546e8c1fcdc4