### PR TITLE
Fix RootLayout return statement

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,10 +1,9 @@
 import { Stack } from "expo-router";
 
 export default function RootLayout() {
-  return <Stack
-    screenOptions={{
-      headerShown: false,
-    }}>
+  return (
+    <Stack screenOptions={{ headerShown: false }}>
       <Stack.Screen name="index" />
-</Stack>;
+    </Stack>
+  );
 }


### PR DESCRIPTION
## Summary
- correct JSX return block in `RootLayout` of `_layout.tsx`

## Testing
- `npm run lint` *(fails: expo not found)*
- `npx expo doctor` *(fails: 403 Forbidden)*
- `npx expo prebuild --platform android` *(fails: 403 Forbidden)*
- `npx expo run:android` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685260dd7fb4832481b3b908bff28384